### PR TITLE
Fix cleanup job for unsubmitted forms

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -30,16 +30,15 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
-    );
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
-        createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
-        },
+        createdAt: { lt: sevenDaysAgo },
+      },
+      select: {
+        token: true,
+        entityId: true,
+        productId: true,
       },
     });
 

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -29,7 +29,7 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const sevenDaysAgoPlusOneDay = new Date(
       sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
     );


### PR DESCRIPTION
**Summary:**
This PR fixes and improves the scheduled cleanup job that deletes tokens, relationships, corpus items, and entities for unsubmitted public forms older than 7 days. The goal is to prevent database clutter while ensuring safe and efficient deletion.

**Changes Made:**

- Corrected date calculation to properly identify tokens older than 7 days.
- Updated query logic to select all expired tokens (createdAt < sevenDaysAgo).
- Replaced findFirst with findMany and used deleteMany for bulk relationship deletion.
- Added safety checks before deleting entities to avoid unsafe deletion.
- Wrapped cleanup per token in transactions with robust error handling to ensure one failure doesn’t block other tokens.
- Added structured logging for better debugging.
- Ensured job status is updated correctly (completed or failed).

**Trade-offs Considered:**

- Running a transaction per token increases database overhead slightly but guarantees isolated failures won’t affect other tokens.
- Bulk deletion is used where safe to improve performance and reduce queries.

**Testing Notes:**

- Verified expired tokens are deleted correctly after 7 days.
- Confirmed entities and related corpus items are deleted safely.
- Logged failures do not interrupt other token cleanup operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Properly expires and removes tokens older than 7 days.
  * Cleans up all related data, including multiple relationships, to prevent leftovers.
  * Prevents partial failures from blocking subsequent cleanups.

* Reliability
  * Uses per-token isolated cleanup so failures for one token don’t stop others.
  * Accurately updates job status after processing.

* Chores
  * Streamlined expired unsubmitted forms cleanup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->