### PR TITLE
Fix(form-cleanup): improve token cleanup with batching and absolute time handling

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -34,6 +34,11 @@ export const cleanupUnsubmittedForms = async (job: JobScheduleQueue) => {
     while (true) {
       const expiredTokens = await prisma.publicFormsTokens.findMany({
         where: { createdAt: { lt: sevenDaysAgo } },
+        select: {
+          entityId: true,
+          token: true,
+          productId: true,
+        },
         take: BATCH_SIZE,
       });
 
@@ -48,6 +53,9 @@ export const cleanupUnsubmittedForms = async (job: JobScheduleQueue) => {
         where: {
           product_id: { in: expiredTokens.map((t) => t.productId) },
           status: "new" as RelationshipStatus,
+        },
+        select: {
+          id: true,
         },
       });
 


### PR DESCRIPTION

Issues found

1. The calculation of seven days ago was not correct. Since date is in milliseconds, the calculation is resulting instead in 10 minutes ago.
2. Suppose today is September 10 and the cleanup job is scheduled to run at midnight. If the job is delayed or re-queued and actually runs at 1:00 AM, using relative time would calculate "7 days ago" as September 3, 1:00 AM. As a result, tokens created between September 3, 0:00 and 1:00 AM would be missed and not deleted. Using absolute midnight-to-midnight ensures that all tokens older than 7 days are correctly included, even if the job is delayed.
3. Making multiple individual database requests for each token and its associated objects causes repeated opening and closing of connections, which hurts performance. Instead, deletions should be done in batches, with the batch size tailored to the size and number of fields in the models.
4. The variable name `token` for each `expiredToken` is confusing because accessing the field requires `token.token`. It would be clearer to rename the object to something like `expiredToken` or `formToken` to make the code more readable.
5. It’s better to use a union for statuses like `"new"` to ensure type safety and avoid typos.
6. This might not be that relevant but the current filter deletes tokens that are between 6 and 7 days old, instead of deleting those that are older than 7 days (not sure about the functional requirement).

Trades off considered

- Delete All at Once - At a previous company I worked at, bulk-deleting all expired records in a single query was the approach used. However, because there were too many records, the operation often timed out. Over time, this caused records to accumulate, leading to a database storage spike.

 - Delete Individually - Deleting records one by one avoids timeouts but results in excessive DB round trips. Each record requires a separate request, which is highly inefficient and slows down the cleanup process.

 - Batch Deletion (Chosen Approach) - Deleting in configurable batches strikes the right balance. It prevents timeouts while avoiding the inefficiencies of one-by-one deletes. The batch size can be tuned based on factors like database size, indexing, and workload patterns.
 
 What can be improved
  - Using consistent casing. Currently for variable names camelCase is being used and for variable snake_case is used. 
  - Logging: currently, errors are logged using console.error, which is not as useful for production debugging. We could replace this with Winston (or a similar structured logging library). Winston supports labels and log levels.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate cleanup timing for unsubmitted forms, reducing premature or missed deletions.
  * Improved error handling to ensure jobs clearly report success or failure.

* **Refactor**
  * Switched to batched, transactional cleanup to handle large volumes more efficiently and reliably, minimizing partial deletions and timeouts.

* **Chores**
  * Standardized status values used during cleanup and job updates for clearer operational tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->