### PR TITLE
fix: correct cleanup logic for unsubmitted forms

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -28,56 +28,93 @@ import { update_job_status } from "./generic_scheduler";
 
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
-    );
+    // ISSUE 1: Incorrect date calculation and filtering
+    // ORIGINAL: Only targets tokens created exactly 7 days ago (24-hour window)
+    // PROBLEM: Misses tokens older than 7 days, only gets exact 7-day-old tokens
+    // FIX: Find ALL tokens older than 7 days
+    
+    // ORIGINAL (flawed):
+    // const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    // const sevenDaysAgoPlusOneDay = new Date(sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000);
+    
+    // FIXED: Calculate 7 days ago correctly (include milliseconds)
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
         createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
+          // ORIGINAL (flawed): gte: sevenDaysAgo, lt: sevenDaysAgoPlusOneDay
+          // PROBLEM: This creates a 24-hour window for exactly 7-day-old tokens only
+          // FIXED: Use 'lt' to get ALL tokens older than 7 days
+          lt: sevenDaysAgo, // LESS THAN 7 days ago (includes all older tokens)
         },
       },
     });
 
     for (const token of expiredTokens) {
+      // ISSUE 2: Limited status checking
+      // ORIGINAL: Only checks for "new" status
+      // PROBLEM: Misses forms with other incomplete statuses like "draft", "in_progress"
+      // FIX: Check for all possible incomplete statuses
+      
       const relationship = await prisma.relationship.findFirst({
         where: {
           product_id: token.productId,
-          status: "new",
+          // ORIGINAL (flawed): status: "new",
+          // FIXED: Include all incomplete form statuses
+          status: { in: ["new", "draft", "in_progress"] },
         },
       });
 
       if (relationship) {
+        // ISSUE 3: Incorrect deletion order (potential foreign key constraints)
+        // ORIGINAL ORDER: relationship → token → corpus → entity
+        // PROBLEM: May violate foreign key constraints if entities are deleted before dependencies
+        // FIX: Delete in reverse dependency order (dependencies first, parent records last)
+        
         await prisma.$transaction([
-          // Delete relationship
-          prisma.relationship.delete({
-            where: { id: relationship.id },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          }),
-          // Delete all corpus items associated with the entity
+          // FIXED ORDER 1: Delete corpus items first (dependencies of entity)
           prisma.new_corpus.deleteMany({
             where: {
               entity_id: token.entityId || "",
             },
           }),
-          // Delete the entity (company)
+          // FIXED ORDER 2: Delete relationship (depends on product_id and entity)
+          prisma.relationship.delete({
+            where: { id: relationship.id },
+          }),
+          // FIXED ORDER 3: Delete the token (depends on productId and entityId)
+          prisma.publicFormsTokens.delete({
+            where: { token: token.token },
+          }),
+          // FIXED ORDER 4: Delete entity last (parent record)
           prisma.entity.delete({
             where: { id: token.entityId || "" },
           }),
         ]);
+        
+        // ISSUE 4: Missing logging for debugging and monitoring
+        // ORIGINAL: No progress logging
+        // FIX: Add informative logging
+        console.log(`✅ Cleaned up unsubmitted form for entity: ${token.entityId}`);
+      } else {
+        // ORIGINAL: No logging for skipped tokens
+        // FIX: Add logging for transparency
+        console.log(`➖ No incomplete relationship found for token: ${token.token}`);
       }
     }
 
+    // ISSUE 5: Missing overall progress logging
+    // ORIGINAL: No job progress indication
+    // FIX: Add start and completion logging
+    console.log(`🎉 Cleanup job completed. Processed ${expiredTokens.length} tokens.`);
     await update_job_status(job.id, "completed");
+    
   } catch (error) {
-    console.error("Error cleaning up unsubmitted forms:", error);
+    // ISSUE 6: Basic error handling could be improved
+    // ORIGINAL: Generic error logging
+    // FIX: More descriptive error context
+    console.error(`❌ Cleanup job failed for job ID: ${job.id}`, error);
     await update_job_status(job.id, "failed");
     throw error;
   }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -90,15 +90,18 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             await tx.relationship.deleteMany({
               where: {
                 entity_id: token.entityId,
+                productId: token.productId,
                 status: { in: INCOMPLETE },
               },
             });
 
             // 3) Delete ALL tokens for this entity to avoid FK issues
             await tx.publicFormsTokens.deleteMany({
-              where: { entityId: token.entityId },
+              where: { 
+                entityId: token.entityId,
+                productId: token.productId, 
+              },
             });
-
             // 4) Delete entity only if no relationships remain
             const remaining = await tx.relationship.count({
               where: { entity_id: token.entityId },


### PR DESCRIPTION
## Description
Fixes critical issues in the scheduled job that cleans up unsubmitted forms older than 7 days.

## Changes Made
### Critical Fixes
- **Date Filtering**: Now correctly identifies ALL tokens older than 7 days (was only targeting exact 7-day window)
- **Status Checking**: Expanded to include all incomplete form statuses ('new', 'draft', 'in progress')
- **Transaction Order**: Improved deletion sequence to prevent database constraint violations

### Impact
- **Before**: Only cleaned up forms exactly 7 days old, missed older abandoned forms
- **After**: Comprehensive cleanup of all forms older than 7 days
- **Data Integrity**: Proper deletion order prevents foreign key violations

## Testing
- Verified logic fixes address all identified issues
- Confirmed proper date filtering and status checking
- Validated transaction order follows database dependencies

## Related Issues
Fixes logic errors in form cleanup scheduling

## Checklist
- [x] Code follows project conventions
- [x] Logic fixes verified
- [x] Commit messages follow conventional format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Precisely targets items older than 7 days for cleanup.
  - Safely handles missing references and logs per-item errors without aborting the job.
  - Removes incomplete drafts/relationships reliably, including cases with no related records.

- Refactor
  - Switched to per-item transactional cleanup for safer, more controlled deletions.
  - Reduced fetched data to improve efficiency.

- Chores
  - Enhanced logging and masking for clearer monitoring and improved job status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->