### PR TITLE
Fix bugs in cleanup_unsubmitted_forms scheduled job

### DIFF
--- a/tests/unsubmitted_forms/README.md
+++ b/tests/unsubmitted_forms/README.md
@@ -14,32 +14,57 @@
 ### 2. Query Logic Error
 **Problem:** Original query only found tokens from exactly 7 days ago (a 24-hour window), missing tokens that were 8, 9, 10+ days old.
 
-**Fix:** Changed to `lt: sevenDaysAgo` to find all tokens older than 7 days.
+**Fix:** Changed to `lt: cutoffDate` to find all tokens older than 7 days.
 
-### 3. Foreign Key Constraint Order
-**Problem:** Deletion order could fail if corpus items reference entity_id.
+### 3. Missing Submission Status Check
+**Problem:** Query fetched all old tokens regardless of whether the form was submitted, risking deletion of valid submitted data.
 
-**Fix:** Reordered deletions to delete corpus items before entities.
+**Fix:** Added `submittedAt: null` filter to only fetch unsubmitted tokens.
 
-### 4. Orphaned Tokens Not Handled
-**Problem:** If no relationship existed, the token was never deleted.
+### 4. Wrong Relationship Deletion
+**Problem:** Relationship query only filtered by `product_id` and `status`, which could accidentally delete relationships belonging to other valid tokens that share the same product.
 
-**Fix:** Always delete the token, conditionally delete relationship only if it exists.
+**Fix:** Added `entity_id: { in: entityIds }` to the relationship query to ensure we only delete relationships tied to the specific expired entities.
 
-### 5. Null EntityId Handling
-**Problem:** Passing empty string `""` to delete queries when entityId is null would cause errors.
+### 5. Foreign Key Constraint Order
+**Problem:** Deletion order could fail if child records reference parent tables.
 
-**Fix:** Only delete entity-related data if entityId actually exists.
+**Fix:** Reordered deletions: relationships → corpus items → tokens → entities (children before parents).
 
-### 6. N+1 Query Problem (Performance)
+### 6. Null EntityId Handling
+**Problem:** Passing null/undefined values to delete queries would cause errors.
+
+**Fix:** Filter out null values using `filter((id): id is string => Boolean(id))` before batch operations.
+
+### 7. N+1 Query Problem (Performance)
 **Problem:** Loop with individual `findFirst` and `$transaction` per token would cause thousands of DB calls at scale.
 
-**Fix:** Refactored to batch approach - collect all IDs upfront, use `deleteMany` with `{ in: [...] }` in a single transaction.
+**Fix:** Refactored to batch approach using `deleteMany` with `{ in: [...] }` in a single transaction.
+
+### 8. Memory Issues with Large Datasets
+
+**Problem:** Loading all expired tokens at once could crash the process with Out of Memory errors.
+
+**Fix:** Implemented batching with `take: BATCH_SIZE` (1000 records) in a while loop to process in chunks.
+
+### 9. Duplicate IDs in Queries
+
+**Problem:** Multiple tokens could share the same entityId/productId, causing unnecessary parameter bloat in IN clauses.
+
+**Fix:** Deduplicate IDs using `[...new Set(...)]` before batch operations.
+
+## Final Solution Features
+
+- **Configurable constants:** `BATCH_SIZE` and `RETENTION_DAYS` at the top for easy adjustment
+- **Batched processing:** Handles millions of records without memory issues
+- **Safe relationship deletion:** Only deletes relationships tied to expired entities
+- **Atomic transactions:** Each batch is processed in a single transaction
+- **Observability:** Logs total counts of deleted records for monitoring
 
 ## Trade-offs Considered
 
-- **Batch vs Loop:** Chose batch deletions for O(1) DB round-trips instead of O(N). Trade-off: for very large datasets (50k+ records), the `IN` clause could hit DB limits - would need chunking in production.
+- **Batching:** Chose 1000 records per batch as a balance between performance and memory. Could be tuned based on server resources.
 
-- **Memory:** Still loading all expired tokens into memory. For millions of records, would need cursor-based pagination.
+- **Extra query for relationships:** Added a `findMany` to get relationship IDs before deletion. This adds one query per batch but ensures we never delete the wrong relationships.
 
-- **Atomicity:** Single transaction means all-or-nothing. If one delete fails, everything rolls back - which is generally safer for data consistency.
+- **Atomicity per batch:** Each batch is atomic, not the entire job. If the job fails mid-way, some batches will have been committed. This is acceptable for a cleanup job - it can safely be re-run.

--- a/tests/unsubmitted_forms/README.md
+++ b/tests/unsubmitted_forms/README.md
@@ -1,0 +1,45 @@
+# Cleanup Unsubmitted Forms - Solution
+
+## Video Explanation
+
+[Watch the Loom video](https://www.loom.com/share/3d0413ae4c2845cab8a3e3c93b62f9e3)
+
+## Issues Found & Fixes
+
+### 1. Date Calculation Bug
+**Problem:** Missing `* 1000` for milliseconds conversion - was only subtracting ~10 minutes instead of 7 days.
+
+**Fix:** Added `* 1000` to convert seconds to milliseconds.
+
+### 2. Query Logic Error
+**Problem:** Original query only found tokens from exactly 7 days ago (a 24-hour window), missing tokens that were 8, 9, 10+ days old.
+
+**Fix:** Changed to `lt: sevenDaysAgo` to find all tokens older than 7 days.
+
+### 3. Foreign Key Constraint Order
+**Problem:** Deletion order could fail if corpus items reference entity_id.
+
+**Fix:** Reordered deletions to delete corpus items before entities.
+
+### 4. Orphaned Tokens Not Handled
+**Problem:** If no relationship existed, the token was never deleted.
+
+**Fix:** Always delete the token, conditionally delete relationship only if it exists.
+
+### 5. Null EntityId Handling
+**Problem:** Passing empty string `""` to delete queries when entityId is null would cause errors.
+
+**Fix:** Only delete entity-related data if entityId actually exists.
+
+### 6. N+1 Query Problem (Performance)
+**Problem:** Loop with individual `findFirst` and `$transaction` per token would cause thousands of DB calls at scale.
+
+**Fix:** Refactored to batch approach - collect all IDs upfront, use `deleteMany` with `{ in: [...] }` in a single transaction.
+
+## Trade-offs Considered
+
+- **Batch vs Loop:** Chose batch deletions for O(1) DB round-trips instead of O(N). Trade-off: for very large datasets (50k+ records), the `IN` clause could hit DB limits - would need chunking in production.
+
+- **Memory:** Still loading all expired tokens into memory. For millions of records, would need cursor-based pagination.
+
+- **Atomicity:** Single transaction means all-or-nothing. If one delete fails, everything rolls back - which is generally safer for data consistency.

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -54,7 +54,6 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       .filter((id): id is string => id !== null && id !== undefined);
 
     // batch delete in a single transaction - order matters for FK constraints
-    // NOTE: for very large datasets (50k+), consider chunking to avoid DB limits on IN clauses
     await prisma.$transaction([
       // delete relationships tied to these products that are still "new" (unsubmitted)
       prisma.relationship.deleteMany({

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -28,17 +28,14 @@ import { update_job_status } from "./generic_scheduler";
 
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
-    );
+    // Find forms that were created more than 7 days ago and have not been submitted
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days in ms
 
+    // get all tokens older than 7 days, not just ones from exactly 7 days ago
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
         createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
+          lt: sevenDaysAgo,
         },
       },
     });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -29,7 +29,7 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const sevenDaysAgoPlusOneDay = new Date(
       sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
     );

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -7,84 +7,113 @@
  This is to prevent the database from being cluttered with unused tokens and entities.
  */
 
-/* Task Instructions:
- * 1. Read and understand the code below
- * 2. Identify ALL issues in the code (there are multiple)
- * 3. Fix the issues and create a working solution
- * 4. Create a PR with clear commit messages
- * 5. Record a 3-5 minute Loom video explaining:
- *    - What issues you found
- *    - How you fixed them
- *    - Any trade-offs you considered
- *
- * Focus on: correctness, performance, error handling, and code clarity
- * Expected time: 45-60 minutes
- */
-
 // For the purpose of this test you can ignore that the imports are not working.
 import type { JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
+const BATCH_SIZE = 1000;
+const RETENTION_DAYS = 7;
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days in ms
+    const cutoffDate = new Date(
+      Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
 
-    // fetch only unsubmitted tokens older than 7 days
-    // submittedAt being null means the form was never submitted
-    const expiredTokens = await prisma.publicFormsTokens.findMany({
-      where: {
-        createdAt: { lt: sevenDaysAgo },
-        submittedAt: null,
-      },
-      select: { token: true, entityId: true, productId: true },
-    });
+    let totalTokensDeleted = 0;
+    let totalEntitiesDeleted = 0;
+    let totalRelationshipsDeleted = 0;
+    let totalCorpusDeleted = 0;
 
-    // nothing to clean up
-    if (expiredTokens.length === 0) {
-      await update_job_status(job.id, "completed");
-      return;
-    }
+    // Process in batches to handle large datasets without memory issues
+    while (true) {
+      const expiredTokens = await prisma.publicFormsTokens.findMany({
+        where: {
+          createdAt: { lt: cutoffDate },
+          submittedAt: null,
+        },
+        select: {
+          token: true,
+          entityId: true,
+          productId: true,
+        },
+        take: BATCH_SIZE,
+      });
 
-    // collect unique ids for batch deletion - dedupe to reduce query size
-    const tokenStrings = [...new Set(expiredTokens.map((t) => t.token))];
-    const entityIds = [
-      ...new Set(
-        expiredTokens
-          .map((t) => t.entityId)
-          .filter((id): id is string => id !== null && id !== undefined),
-      ),
-    ];
-    const productIds = [
-      ...new Set(
-        expiredTokens
-          .map((t) => t.productId)
-          .filter((id): id is string => id !== null && id !== undefined),
-      ),
-    ];
+      if (expiredTokens.length === 0) {
+        break;
+      }
 
-    // batch delete in a single transaction - order matters for FK constraints
-    await prisma.$transaction([
-      // delete relationships tied to these products that are still "new" (unsubmitted)
-      prisma.relationship.deleteMany({
+      // Deduplicate identifiers for batch operations
+      const tokenStrings = [...new Set(expiredTokens.map((t) => t.token))];
+
+      const entityIds = [
+        ...new Set(
+          expiredTokens
+            .map((t) => t.entityId)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      ];
+
+      const productIds = [
+        ...new Set(
+          expiredTokens
+            .map((t) => t.productId)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      ];
+
+      // Find only relationships that belong to these specific expired tokens
+      // This prevents accidentally deleting relationships for non-expired tokens
+      // that may share the same product_id
+      const relationshipsToDelete = await prisma.relationship.findMany({
         where: {
           product_id: { in: productIds },
           status: "new",
+          // Ensure we only delete relationships tied to expired entities
+          entity_id: { in: entityIds },
         },
-      }),
-      // delete corpus items before entities (they reference entity_id)
-      prisma.new_corpus.deleteMany({
-        where: { entity_id: { in: entityIds } },
-      }),
-      // delete the entities
-      prisma.entity.deleteMany({
-        where: { id: { in: entityIds } },
-      }),
-      // finally delete the tokens
-      prisma.publicFormsTokens.deleteMany({
-        where: { token: { in: tokenStrings } },
-      }),
-    ]);
+        select: { id: true },
+      });
+
+      const relationshipIds = relationshipsToDelete.map((r) => r.id);
+
+      // Execute all deletions in a single atomic transaction
+      // Order respects foreign key constraints: children before parents
+      const results = await prisma.$transaction([
+        prisma.relationship.deleteMany({
+          where: { id: { in: relationshipIds } },
+        }),
+
+        prisma.new_corpus.deleteMany({
+          where: { entity_id: { in: entityIds } },
+        }),
+
+        prisma.publicFormsTokens.deleteMany({
+          where: { token: { in: tokenStrings } },
+        }),
+
+        prisma.entity.deleteMany({
+          where: { id: { in: entityIds } },
+        }),
+      ]);
+
+      totalRelationshipsDeleted += results[0].count;
+      totalCorpusDeleted += results[1].count;
+      totalTokensDeleted += results[2].count;
+      totalEntitiesDeleted += results[3].count;
+
+      // If we got fewer than BATCH_SIZE, we've processed everything
+      if (expiredTokens.length < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    console.log(
+      `Cleanup complete: ${totalTokensDeleted} tokens, ${totalEntitiesDeleted} entities, ` +
+        `${totalRelationshipsDeleted} relationships, ${totalCorpusDeleted} corpus items deleted`,
+    );
 
     await update_job_status(job.id, "completed");
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fix date calculation bug that was missing milliseconds conversion
- Fix query logic to properly find forms older than 7 days (not just exactly 7 days old)
- Improve deletion order in transaction to respect foreign key constraints
- Handle edge case where token has no associated relationship
- Batched processing: Handles millions of records without memory issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cleanup now runs in batched, transaction-based operations with retention-based cutoff, deduplication, and aggregated totals for efficient, large-scale deletions.

* **Bug Fixes**
  * Added early-exit when no expired items remain, ensured job status updates, improved error handling and logging.

* **Documentation**
  * Added detailed guidance covering the cleanup approach, edge-case handling, performance trade-offs, safety considerations, and an overview video link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->