### PR TITLE
fix: correct cutoff calculation, close data-leak paths, and harden unsubmitted-forms cleanup job

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -67,25 +67,13 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       for (const token of expiredTokens) {
         if (!token.entityId) {
           console.warn(
-            `Token ${token.token} missing entityId — deleting token only`
+            `Token ${token.token} missing entityId — skipping cleanup`
           );
-          try {
-            const result = await prisma.publicFormsTokens.deleteMany({
-              where: {
-                token: token.token,
-                createdAt: { lt: UNSUBMITTED_FORM_CUTOFF },
-                submittedAt: null,
-              },
-            });
-            if (result.count > 0) {
-              processed++;
-              cleanedInBatch++;
-            }
-          } catch (err) {
-            failed++;
-            failedTokens.add(token.token);
-            console.error(`Failed deleting token ${token.token}:`, err);
-          }
+          failed++;
+          failedTokens.add(token.token);
+          console.error(
+            `Cannot atomically clean up token ${token.token} without an entityId`
+          );
           continue;
         }
 

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -37,6 +37,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
         createdAt: {
           lt: cutoff,
         },
+        submittedAt: null,
       },
     });
 

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -42,35 +42,23 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     });
 
     for (const token of expiredTokens) {
-      const relationship = await prisma.relationship.findFirst({
-        where: {
-          product_id: token.productId,
-          status: "new",
-        },
-      });
-
-      if (relationship) {
-        await prisma.$transaction([
-          // Delete relationship
-          prisma.relationship.delete({
-            where: { id: relationship.id },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          }),
-          // Delete all corpus items associated with the entity
-          prisma.new_corpus.deleteMany({
-            where: {
-              entity_id: token.entityId || "",
-            },
-          }),
-          // Delete the entity (company)
-          prisma.entity.delete({
-            where: { id: token.entityId || "" },
-          }),
-        ]);
+      if (!token.entityId) {
+        console.warn(
+          `Token ${token.token} missing entityId — deleting token only`
+        );
+        await prisma.publicFormsTokens
+          .delete({ where: { token: token.token } })
+          .catch(console.error);
+        continue;
       }
+      await prisma.$transaction([
+        prisma.relationship.deleteMany({
+          where: { product_id: token.productId, status: "new" },
+        }),
+        prisma.publicFormsTokens.delete({ where: { token: token.token } }),
+        prisma.new_corpus.deleteMany({ where: { entity_id: token.entityId } }),
+        prisma.entity.delete({ where: { id: token.entityId } }),
+      ]);
     }
 
     await update_job_status(job.id, "completed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -54,14 +54,23 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
         break;
       }
 
+      let cleanedInBatch = 0;
+
       for (const token of expiredTokens) {
         if (!token.entityId) {
           console.warn(
             `Token ${token.token} missing entityId — deleting token only`
           );
-          await prisma.publicFormsTokens
-            .delete({ where: { token: token.token } })
-            .catch(console.error);
+          try {
+            await prisma.publicFormsTokens.delete({
+              where: { token: token.token },
+            });
+            processed++;
+            cleanedInBatch++;
+          } catch (err) {
+            failed++;
+            console.error(`Failed deleting token ${token.token}:`, err);
+          }
           continue;
         }
 
@@ -79,13 +88,17 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             prisma.entity.delete({ where: { id: token.entityId } }),
           ]);
           processed++;
+          cleanedInBatch++;
         } catch (err) {
           failed++;
           console.error(`Failed cleaning up token ${token.token}:`, err);
         }
       }
 
-      if (expiredTokens.length < BATCH_SIZE) {
+      // Failed records remain eligible for cleanup. Stop if this batch did not
+      // delete anything, otherwise the same full batch would be selected
+      // forever and the job would never update its status.
+      if (cleanedInBatch === 0 || expiredTokens.length < BATCH_SIZE) {
         hasMore = false;
       }
     }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -30,16 +30,12 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
-    );
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
         createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
+          lt: cutoff,
         },
       },
     });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,6 +41,9 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       },
     });
 
+    let processed = 0;
+    let failed = 0;
+
     for (const token of expiredTokens) {
       if (!token.entityId) {
         console.warn(
@@ -51,17 +54,28 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
           .catch(console.error);
         continue;
       }
-      await prisma.$transaction([
-        prisma.relationship.deleteMany({
-          where: { product_id: token.productId, status: "new" },
-        }),
-        prisma.publicFormsTokens.delete({ where: { token: token.token } }),
-        prisma.new_corpus.deleteMany({ where: { entity_id: token.entityId } }),
-        prisma.entity.delete({ where: { id: token.entityId } }),
-      ]);
+      try {
+        await prisma.$transaction([
+          prisma.relationship.deleteMany({
+            where: { product_id: token.productId, status: "new" },
+          }),
+          prisma.publicFormsTokens.delete({ where: { token: token.token } }),
+          prisma.new_corpus.deleteMany({
+            where: { entity_id: token.entityId },
+          }),
+          prisma.entity.delete({ where: { id: token.entityId } }),
+        ]);
+        processed++;
+      } catch (err) {
+        failed++;
+        console.error(`Failed cleaning up token ${token.token}:`, err);
+      }
     }
-
-    await update_job_status(job.id, "completed");
+    console.log(`Cleanup: ${processed} processed, ${failed} failed`);
+    await update_job_status(
+      job.id,
+      failed > 0 ? "completed_with_errors" : "completed"
+    );
   } catch (error) {
     console.error("Error cleaning up unsubmitted forms:", error);
     await update_job_status(job.id, "failed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -30,9 +30,9 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
+      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000
     );
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -39,6 +39,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     );
 
     let processed = 0;
+    let skipped = 0;
     let failed = 0;
     let hasMore = true;
     const failedTokens = new Set<string>();
@@ -91,7 +92,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
               });
 
               if (tokenResult.count === 0) {
-                return false;
+                return "skipped" as const;
               }
 
               await tx.relationship.deleteMany({
@@ -105,14 +106,16 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
                 where: { entity_id: token.entityId },
               });
               await tx.entity.delete({ where: { id: token.entityId } });
-              return true;
+              return "cleaned" as const;
             },
             { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
           );
 
-          if (result) {
+          if (result === "cleaned") {
             processed++;
             cleanedInBatch++;
+          } else {
+            skipped++;
           }
         } catch (err) {
           failed++;
@@ -129,7 +132,9 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       }
     }
 
-    console.log(`Cleanup: ${processed} processed, ${failed} failed`);
+    console.log(
+      `Cleanup: ${processed} cleaned, ${skipped} skipped, ${failed} failed`
+    );
     await update_job_status(
       job.id,
       failed > 0 ? "completed_with_errors" : "completed"

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -23,7 +23,7 @@
  */
 
 // For the purpose of this test you can ignore that the imports are not working.
-import type { JobScheduleQueue } from "@prisma/client";
+import { Prisma, type JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
@@ -38,6 +38,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     let processed = 0;
     let failed = 0;
     let hasMore = true;
+    const failedTokens = new Set<string>();
 
     while (hasMore) {
       const expiredTokens = await prisma.publicFormsTokens.findMany({
@@ -46,6 +47,9 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             lt: cutoff,
           },
           submittedAt: null,
+          ...(failedTokens.size > 0
+            ? { token: { notIn: [...failedTokens] } }
+            : {}),
         },
         take: BATCH_SIZE,
       });
@@ -62,42 +66,72 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             `Token ${token.token} missing entityId — deleting token only`
           );
           try {
-            await prisma.publicFormsTokens.delete({
-              where: { token: token.token },
+            const result = await prisma.publicFormsTokens.deleteMany({
+              where: {
+                token: token.token,
+                createdAt: { lt: cutoff },
+                submittedAt: null,
+              },
             });
-            processed++;
-            cleanedInBatch++;
+            if (result.count > 0) {
+              processed++;
+              cleanedInBatch++;
+            }
           } catch (err) {
             failed++;
+            failedTokens.add(token.token);
             console.error(`Failed deleting token ${token.token}:`, err);
           }
           continue;
         }
 
         try {
-          await prisma.$transaction([
-            prisma.relationship.deleteMany({
-              where: { product_id: token.productId, status: "new" },
-            }),
-            prisma.publicFormsTokens.delete({
-              where: { token: token.token },
-            }),
-            prisma.new_corpus.deleteMany({
-              where: { entity_id: token.entityId },
-            }),
-            prisma.entity.delete({ where: { id: token.entityId } }),
-          ]);
-          processed++;
-          cleanedInBatch++;
+          const result = await prisma.$transaction(
+            async (tx) => {
+              // Re-check eligibility inside the transaction. If the form was
+              // submitted after the batch query, nothing is deleted.
+              const tokenResult = await tx.publicFormsTokens.deleteMany({
+                where: {
+                  token: token.token,
+                  createdAt: { lt: cutoff },
+                  submittedAt: null,
+                },
+              });
+
+              if (tokenResult.count === 0) {
+                return false;
+              }
+
+              await tx.relationship.deleteMany({
+                where: {
+                  product_id: token.productId,
+                  entity_id: token.entityId,
+                  status: "new",
+                },
+              });
+              await tx.new_corpus.deleteMany({
+                where: { entity_id: token.entityId },
+              });
+              await tx.entity.delete({ where: { id: token.entityId } });
+              return true;
+            },
+            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+          );
+
+          if (result) {
+            processed++;
+            cleanedInBatch++;
+          }
         } catch (err) {
           failed++;
+          failedTokens.add(token.token);
           console.error(`Failed cleaning up token ${token.token}:`, err);
         }
       }
 
-      // Failed records remain eligible for cleanup. Stop if this batch did not
-      // delete anything, otherwise the same full batch would be selected
-      // forever and the job would never update its status.
+      // Failed records are excluded from later batches. The no-progress guard
+      // also protects against records that remain eligible after a race or a
+      // database-specific transaction outcome.
       if (cleanedInBatch === 0 || expiredTokens.length < BATCH_SIZE) {
         hasMore = false;
       }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -27,13 +27,16 @@ import { Prisma, type JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const FORM_EXPIRY_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const BATCH_SIZE = 500;
 
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created more than 7 days ago and have not been submitted
-    const cutoff = new Date(Date.now() - SEVEN_DAYS_MS);
+    // Capture one cutoff for the whole run. There is intentionally no lower
+    // bound: every unsubmitted form older than seven days is eligible.
+    const UNSUBMITTED_FORM_CUTOFF = new Date(
+      Date.now() - FORM_EXPIRY_AGE_MS
+    );
 
     let processed = 0;
     let failed = 0;
@@ -44,7 +47,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       const expiredTokens = await prisma.publicFormsTokens.findMany({
         where: {
           createdAt: {
-            lt: cutoff,
+            lt: UNSUBMITTED_FORM_CUTOFF,
           },
           submittedAt: null,
           ...(failedTokens.size > 0
@@ -52,6 +55,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             : {}),
         },
         take: BATCH_SIZE,
+        orderBy: [{ createdAt: "asc" }, { token: "asc" }],
       });
 
       if (expiredTokens.length === 0) {
@@ -69,7 +73,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             const result = await prisma.publicFormsTokens.deleteMany({
               where: {
                 token: token.token,
-                createdAt: { lt: cutoff },
+                createdAt: { lt: UNSUBMITTED_FORM_CUTOFF },
                 submittedAt: null,
               },
             });
@@ -93,7 +97,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
               const tokenResult = await tx.publicFormsTokens.deleteMany({
                 where: {
                   token: token.token,
-                  createdAt: { lt: cutoff },
+                  createdAt: { lt: UNSUBMITTED_FORM_CUTOFF },
                   submittedAt: null,
                 },
               });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -27,50 +27,69 @@ import type { JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const BATCH_SIZE = 500;
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created 7 days ago and have not been submitted
-    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-
-    const expiredTokens = await prisma.publicFormsTokens.findMany({
-      where: {
-        createdAt: {
-          lt: cutoff,
-        },
-        submittedAt: null,
-      },
-    });
+    //Find forms that were created more than 7 days ago and have not been submitted
+    const cutoff = new Date(Date.now() - SEVEN_DAYS_MS);
 
     let processed = 0;
     let failed = 0;
+    let hasMore = true;
 
-    for (const token of expiredTokens) {
-      if (!token.entityId) {
-        console.warn(
-          `Token ${token.token} missing entityId — deleting token only`
-        );
-        await prisma.publicFormsTokens
-          .delete({ where: { token: token.token } })
-          .catch(console.error);
-        continue;
+    while (hasMore) {
+      const expiredTokens = await prisma.publicFormsTokens.findMany({
+        where: {
+          createdAt: {
+            lt: cutoff,
+          },
+          submittedAt: null,
+        },
+        take: BATCH_SIZE,
+      });
+
+      if (expiredTokens.length === 0) {
+        break;
       }
-      try {
-        await prisma.$transaction([
-          prisma.relationship.deleteMany({
-            where: { product_id: token.productId, status: "new" },
-          }),
-          prisma.publicFormsTokens.delete({ where: { token: token.token } }),
-          prisma.new_corpus.deleteMany({
-            where: { entity_id: token.entityId },
-          }),
-          prisma.entity.delete({ where: { id: token.entityId } }),
-        ]);
-        processed++;
-      } catch (err) {
-        failed++;
-        console.error(`Failed cleaning up token ${token.token}:`, err);
+
+      for (const token of expiredTokens) {
+        if (!token.entityId) {
+          console.warn(
+            `Token ${token.token} missing entityId — deleting token only`
+          );
+          await prisma.publicFormsTokens
+            .delete({ where: { token: token.token } })
+            .catch(console.error);
+          continue;
+        }
+
+        try {
+          await prisma.$transaction([
+            prisma.relationship.deleteMany({
+              where: { product_id: token.productId, status: "new" },
+            }),
+            prisma.publicFormsTokens.delete({
+              where: { token: token.token },
+            }),
+            prisma.new_corpus.deleteMany({
+              where: { entity_id: token.entityId },
+            }),
+            prisma.entity.delete({ where: { id: token.entityId } }),
+          ]);
+          processed++;
+        } catch (err) {
+          failed++;
+          console.error(`Failed cleaning up token ${token.token}:`, err);
+        }
+      }
+
+      if (expiredTokens.length < BATCH_SIZE) {
+        hasMore = false;
       }
     }
+
     console.log(`Cleanup: ${processed} processed, ${failed} failed`);
     await update_job_status(
       job.id,

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,29 +41,27 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     let processed = 0;
     let skipped = 0;
     let failed = 0;
-    let hasMore = true;
-    const failedTokens = new Set<string>();
+    let lastToken: string | undefined;
 
-    while (hasMore) {
+    while (true) {
       const expiredTokens = await prisma.publicFormsTokens.findMany({
         where: {
           createdAt: {
             lt: UNSUBMITTED_FORM_CUTOFF,
           },
           submittedAt: null,
-          ...(failedTokens.size > 0
-            ? { token: { notIn: [...failedTokens] } }
+          ...(lastToken !== undefined
+            ? { token: { gt: lastToken } }
             : {}),
         },
         take: BATCH_SIZE,
-        orderBy: [{ createdAt: "asc" }, { token: "asc" }],
+        // Token is unique and provides a stable keyset for bounded paging.
+        orderBy: { token: "asc" },
       });
 
       if (expiredTokens.length === 0) {
         break;
       }
-
-      let cleanedInBatch = 0;
 
       for (const token of expiredTokens) {
         if (!token.entityId) {
@@ -71,7 +69,6 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             `Token ${token.token} missing entityId — skipping cleanup`
           );
           failed++;
-          failedTokens.add(token.token);
           console.error(
             `Cannot atomically clean up token ${token.token} without an entityId`
           );
@@ -113,35 +110,39 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
 
           if (result === "cleaned") {
             processed++;
-            cleanedInBatch++;
           } else {
             skipped++;
           }
         } catch (err) {
           failed++;
-          failedTokens.add(token.token);
           console.error(`Failed cleaning up token ${token.token}:`, err);
         }
       }
 
-      // Failed records are excluded from later batches. The no-progress guard
-      // also protects against records that remain eligible after a race or a
-      // database-specific transaction outcome.
-      if (cleanedInBatch === 0 || expiredTokens.length < BATCH_SIZE) {
-        hasMore = false;
+      // Advance regardless of whether records cleaned successfully. This
+      // leaves failures in the database for a later scheduled retry without
+      // selecting them again during this run.
+      lastToken = expiredTokens[expiredTokens.length - 1].token;
+      if (expiredTokens.length < BATCH_SIZE) {
+        break;
       }
     }
 
     console.log(
-      `Cleanup: ${processed} cleaned, ${skipped} skipped, ${failed} failed`
+      `Cleanup summary: processed=${processed}, skipped=${skipped}, failed=${failed}`
     );
-    await update_job_status(
-      job.id,
-      failed > 0 ? "completed_with_errors" : "completed"
-    );
+    // The scheduler supports completed and failed statuses. A run with
+    // unresolved records is not fully successful, so report it as failed.
+    await update_job_status(job.id, failed > 0 ? "failed" : "completed");
   } catch (error) {
     console.error("Error cleaning up unsubmitted forms:", error);
-    await update_job_status(job.id, "failed");
+    try {
+      await update_job_status(job.id, "failed");
+    } catch (statusError) {
+      // Do not replace the original job-level error with a status-update
+      // failure. The original error is the actionable failure to the caller.
+      console.error("Failed to update cleanup job status:", statusError);
+    }
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
The unsubmitted-forms cleanup job had a critical date-math bug that made it query almost the wrong time window entirely, plus several correctness, performance, and error-handling issues that could leave orphaned tokens/entities in the database, silently fail on the first bad row, or in some cases loop indefinitely over the same unresolved rows within a single run.

## Issues found
- **Date arithmetic bug**: `7 * 24 * 60 * 60` was computed in seconds, not ms, so the cutoff was ~10 minutes ago instead of 7 days.
- **Rolling single-day window**: original query only matched tokens that turned *exactly* 7 days old today (`gte`/`lt` pair). Any missed job run meant that day's cohort was skipped permanently.
- **Indirect "not submitted" check**: inferred via a `relationship` with `status: "new"` rather than checking the token's own state.
- **Silent data leak**: if no matching relationship was found, the token/entity were never deleted at all — the exact clutter problem this job exists to prevent.
- **Race condition**: a `findFirst` check followed by a separate transaction left a window where a user could submit between the check and the delete.
- **N+1 / unbounded query**: sequential `findFirst` + transaction per token, no pagination on the initial fetch.
- **Fail-fast on first error**: one thrown error aborted the entire batch and marked the whole job `failed`, even for tokens never attempted.
- **Silent masking**: `token.entityId || ""` converted a missing entity link into a delete-by-empty-string no-op instead of surfacing the bad state.
- **Latent infinite-loop risk in earlier offset-based pagination**: without a stable cursor, a batch containing unresolved (failed) rows would be re-fetched identically on the next page request within the same run, since `where` alone doesn't change as failures accumulate.

## What changed
- Fixed cutoff to correct ms-based 7-day calculation (single variable, no compounding).
- Query matches all tokens older than cutoff (`lt: cutoff`), not a single-day slice.
- Added `submittedAt: null` filter to check the token's own state directly — **assumption, needs schema confirmation**.
- Replaced offset-based pagination with **keyset (cursor) pagination** on `token` (`orderBy: token asc`, `token: { gt: lastToken }`). This guarantees forward progress through the batch each iteration regardless of whether individual rows succeed or fail, closing the infinite-loop risk above.
- Replaced the pre-check `findFirst` + conditional with a **re-verification `deleteMany` on the token itself inside the transaction** (`createdAt`/`submittedAt` re-checked at delete time). If the token no longer matches — e.g. the user submitted between batch fetch and transaction — the transaction short-circuits and nothing downstream is deleted. This closes the race window more rigorously than a pre-transaction check alone.
- Downstream deletes (`relationship`, `new_corpus`, `entity`) only proceed if the token delete actually matched a row, ensuring token/entity cleanup happens consistently regardless of whether a relationship exists.
- Transaction now runs at **`Serializable` isolation level** for stronger consistency guarantees under concurrent access.
- **Behavior change for missing `entityId`**: previously the token was deleted immediately and the entity left in an inconsistent state; now the row is **skipped and counted as `failed`**, left in place for a later run and for visibility rather than being silently cleaned up. This treats a malformed row as something requiring attention rather than something to auto-heal.
- Per-token try/catch with `processed` / `skipped` / `failed` counters — one bad row no longer blocks the rest of the batch.
- Job status logic uses the existing `completed` / `failed` enum values only (no new status introduced) — reports `failed` if any row failed, `completed` otherwise. This resolves the earlier open question about whether a `completed_with_errors` value exists on `JobScheduleQueue`, by not depending on it.
- Status-update failures in the outer `catch` are now caught separately so a failure to write job status doesn't mask or replace the original underlying error.

## Trade-offs
- **Per-token transaction vs. one transaction for the whole batch**: partial progress is preserved over all-or-nothing atomicity, since a cleanup job has no user-facing urgency and holding one long-lived lock across the whole batch is worse than incremental progress.
- **Serializable isolation vs. contention**: stronger consistency guarantee, at the cost of a higher chance of serialization conflicts under concurrent load. Conflicts aren't retried with backoff — they fall into the catch block, are logged as `failed`, and are picked up on the next scheduled run. This is an intentional simplification, not an oversight.
- **Skip-and-flag vs. delete-only-token for missing `entityId`**: chose to leave these rows in place and surface them as failures on every subsequent run until resolved, rather than silently deleting the token and leaving an orphaned/inconsistent entity behind. This trades "self-healing" for "escalating," which seems more appropriate for financial-institution client data.
- **Reporting `failed` instead of a partial-success state**: without confirmation that the job status enum supports something like `completed_with_errors`, the safer choice was to use the existing enum and let a non-zero `failed` count fail the whole run, rather than assume a status value exists and risk a runtime/type error.