### PR TITLE
fix: correct cleanup_unsubmitted_forms date logic and harden the job against partial failure

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,11 +41,18 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     });
 
     for (const token of expiredTokens) {
+      if (!token.entityId) {
+        await prisma.publicFormsTokens.delete({
+          where: { token: token.token },
+        });
+        continue;
+      }
+
       await prisma.$transaction([
         // Delete relationship
         prisma.relationship.deleteMany({
           where: {
-            entity_id: token.entityId || "",
+            entity_id: token.entityId,
             product_id: token.productId,
             status: "new",
           },
@@ -57,12 +64,12 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
         // Delete all corpus items associated with the entity
         prisma.new_corpus.deleteMany({
           where: {
-            entity_id: token.entityId || "",
+            entity_id: token.entityId,
           },
         }),
         // Delete the entity (company)
         prisma.entity.delete({
-          where: { id: token.entityId || "" },
+          where: { id: token.entityId },
         }),
       ]);
     }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,35 +41,30 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     });
 
     for (const token of expiredTokens) {
-      const relationship = await prisma.relationship.findFirst({
-        where: {
-          product_id: token.productId,
-          status: "new",
-        },
-      });
-
-      if (relationship) {
-        await prisma.$transaction([
-          // Delete relationship
-          prisma.relationship.delete({
-            where: { id: relationship.id },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          }),
-          // Delete all corpus items associated with the entity
-          prisma.new_corpus.deleteMany({
-            where: {
-              entity_id: token.entityId || "",
-            },
-          }),
-          // Delete the entity (company)
-          prisma.entity.delete({
-            where: { id: token.entityId || "" },
-          }),
-        ]);
-      }
+      await prisma.$transaction([
+        // Delete relationship
+        prisma.relationship.deleteMany({
+          where: {
+            entity_id: token.entityId || "",
+            product_id: token.productId,
+            status: "new",
+          },
+        }),
+        // // Delete the token
+        prisma.publicFormsTokens.delete({
+          where: { token: token.token },
+        }),
+        // Delete all corpus items associated with the entity
+        prisma.new_corpus.deleteMany({
+          where: {
+            entity_id: token.entityId || "",
+          },
+        }),
+        // Delete the entity (company)
+        prisma.entity.delete({
+          where: { id: token.entityId || "" },
+        }),
+      ]);
     }
 
     await update_job_status(job.id, "completed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -31,15 +31,11 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
-    );
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
         createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
+          lt: sevenDaysAgo,
         },
       },
     });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -40,41 +40,62 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       },
     });
 
-    for (const token of expiredTokens) {
-      if (!token.entityId) {
-        await prisma.publicFormsTokens.delete({
-          where: { token: token.token },
-        });
-        continue;
-      }
+    let deleted = 0;
+    let failed = 0;
 
-      await prisma.$transaction([
-        // Delete relationship
-        prisma.relationship.deleteMany({
-          where: {
-            entity_id: token.entityId,
-            product_id: token.productId,
-            status: "new",
-          },
-        }),
-        // // Delete the token
-        prisma.publicFormsTokens.delete({
-          where: { token: token.token },
-        }),
-        // Delete all corpus items associated with the entity
-        prisma.new_corpus.deleteMany({
-          where: {
-            entity_id: token.entityId,
-          },
-        }),
-        // Delete the entity (company)
-        prisma.entity.delete({
-          where: { id: token.entityId },
-        }),
-      ]);
+    for (const token of expiredTokens) {
+      try {
+        if (!token.entityId) {
+          console.warn(
+            `Token ${token.token} (product ${token.productId}, created ${token.createdAt.toISOString()}) has no entityId, deleting token only`,
+          );
+          await prisma.publicFormsTokens.delete({
+            where: { token: token.token },
+          });
+          deleted++;
+          continue;
+        }
+
+        await prisma.$transaction([
+          // Delete relationship
+          prisma.relationship.deleteMany({
+            where: {
+              entity_id: token.entityId,
+              product_id: token.productId,
+              status: "new",
+            },
+          }),
+          // // Delete the token
+          prisma.publicFormsTokens.delete({
+            where: { token: token.token },
+          }),
+          // Delete all corpus items associated with the entity
+          prisma.new_corpus.deleteMany({
+            where: {
+              entity_id: token.entityId,
+            },
+          }),
+          // Delete the entity (company)
+          prisma.entity.delete({
+            where: { id: token.entityId },
+          }),
+        ]);
+
+        deleted++;
+      } catch (error) {
+        failed++;
+        console.error(
+          `Failed to clean up token ${token.token}:`,
+          error,
+        );
+      }
     }
 
-    await update_job_status(job.id, "completed");
+    console.log(
+      `cleanup_unsubmitted_forms: ${expiredTokens.length} expired, ${deleted} deleted, ${failed} failed`,
+    );
+
+    await update_job_status(job.id, failed > 0 ? "failed" : "completed");
   } catch (error) {
     console.error("Error cleaning up unsubmitted forms:", error);
     await update_job_status(job.id, "failed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -30,7 +30,7 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const sevenDaysAgoPlusOneDay = new Date(
       sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
     );

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -27,6 +27,8 @@ import type { JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
+const BATCH_SIZE = 1000;
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
@@ -38,6 +40,14 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
           lt: sevenDaysAgo,
         },
       },
+      select: {
+        token: true,
+        entityId: true,
+        productId: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+      take: BATCH_SIZE,
     });
 
     let deleted = 0;
@@ -57,6 +67,10 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
         }
 
         await prisma.$transaction([
+          // Delete the token
+          prisma.publicFormsTokens.delete({
+            where: { token: token.token },
+          }),
           // Delete relationship
           prisma.relationship.deleteMany({
             where: {
@@ -64,10 +78,6 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
               product_id: token.productId,
               status: "new",
             },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
           }),
           // Delete all corpus items associated with the entity
           prisma.new_corpus.deleteMany({


### PR DESCRIPTION
What this fixes

1. **The cutoff was 10 minutes, not 7 days**
    7 * 24 * 60 * 60 is seven days in seconds, but Date.now() is in milliseconds. This is a data-loss bug — the job was targeting forms users had only just started filling in.
2. **The query only ever matched a single day**
    A gte/lt pair matched one 24-hour slice, so anything older than 8 days was never picked up. If a run failed or was skipped, those records were orphaned permanently with no way to catch up. Now lt: cutoff, which is self-healing.
3. **Relationships were matched on the wrong key**
    The lookup used product_id alone — the form, not the applicant — so findFirst returned an arbitrary relationship belonging to any entity that had filled in the same form, and deleted it. Now scoped to entity_id and switched to deleteMany so multiple matches are cleared. Removing the surrounding if (relationship) guard fixes a second problem: when no relationship was found the token and entity were skipped entirely, so the abandoned forms this job exists to clean up were never deleted.

4. **|| "" turned a null entityId into a guaranteed crash**
   `entity.delete({ id: "" })` matches nothing and throws, rolling back the transaction and failing the whole run — permanently, since the same row was hit every subsequent night. Now handled with an explicit guard.
5. **One bad record aborted the entire run**
    A single try/catch wrapped the loop. Each token is now processed independently, with per-token errors logged and a summary of how many were deleted vs failed.
6. **Unbounded fetch and implicit delete order**
    findMany had no limit. Now capped at BATCH_SIZE, ordered oldest-first, selecting only the fields used. Deletes run token first, then the entity’s children, then the entity — so nothing can pick the record up mid-transaction and foreign keys never block the final delete.

**Trade-offs**

No pagination loop. Paginating while deleting the rows you’re iterating over invites skipped records or an infinite loop. One bounded batch per nightly run is simpler and can’t hang — since the query has no lower bound, the remainder stays eligible tomorrow. If a backlog drains too slowly, raise BATCH_SIZE rather than add a cursor.

Tokens with no entity are deleted rather than kept for review. A token with no entity can’t ever be completed, and keeping it defeats the purpose of the job. It’s logged with a warning since it shouldn’t happen in normal operation.

A failing token still fails every night. Per-token isolation stops one bad record blocking the rest, but that record is retried indefinitely. A proper fix needs a retry count or dead-letter on the token — that’s a schema change, so out of scope here.