### PR TITLE
fix: cleanup job was deleting live sessions and keeping abandoned ones

### DIFF
--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -48,6 +48,80 @@ const findExpiredTokens = (cutoff: Date): Promise<ExpiredToken[]> =>
     take: BATCH_SIZE,
   });
 
+// deleteMany so a token that has already gone is not an error.
+const deleteTokenOnly = (token: string) =>
+  prisma.publicFormsTokens.deleteMany({ where: { token } });
+
+// In use means an unexpired token points at it, or a relationship has moved
+// past "new". One pair of queries per batch.
+const findEntitiesInUse = async (entityIds: string[], cutoff: Date) => {
+  if (entityIds.length === 0) return new Set<string>();
+
+  const [live, finished] = await Promise.all([
+    prisma.publicFormsTokens.findMany({
+      where: { entityId: { in: entityIds }, createdAt: { gte: cutoff } },
+      select: { entityId: true },
+    }),
+    prisma.relationship.findMany({
+      where: { entity_id: { in: entityIds }, status: { not: "new" } },
+      select: { entity_id: true },
+    }),
+  ]);
+
+  return new Set<string>([
+    ...live.map((t) => t.entityId).filter((id): id is string => !!id),
+    ...finished.map((r) => r.entity_id),
+  ]);
+};
+
+// The bulk check is a few seconds old by now, so ask again before deleting.
+// Someone submitting in that window is the case we cannot get wrong.
+// Returns false if the entity turns out to be in use.
+const deleteEntityIfUnused = (
+  entityId: string,
+  productId: string,
+  cutoff: Date,
+) =>
+  prisma.$transaction(async (tx) => {
+    const [live, finished] = await Promise.all([
+      tx.publicFormsTokens.count({
+        where: { entityId, createdAt: { gte: cutoff } },
+      }),
+      tx.relationship.count({
+        where: { entity_id: entityId, status: { not: "new" } },
+      }),
+    ]);
+
+    if (live > 0 || finished > 0) return false;
+
+    await tx.relationship.deleteMany({
+      where: { entity_id: entityId, product_id: productId, status: "new" },
+    });
+    // All of this entity's tokens, or the next pass would try to delete an
+    // entity that has already gone.
+    await tx.publicFormsTokens.deleteMany({ where: { entityId } });
+    await tx.new_corpus.deleteMany({ where: { entity_id: entityId } });
+    await tx.entity.delete({ where: { id: entityId } });
+
+    return true;
+  });
+
+// The token always goes. The entity only goes if nothing else needs it.
+// Returns true if the entity was removed.
+const cleanUpToken = async (
+  { token, entityId, productId }: ExpiredToken,
+  entitiesInUse: Set<string>,
+  cutoff: Date,
+): Promise<boolean> => {
+  if (entityId && !entitiesInUse.has(entityId)) {
+    const removed = await deleteEntityIfUnused(entityId, productId, cutoff);
+    if (removed) return true;
+  }
+
+  await deleteTokenOnly(token);
+  return false;
+};
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     const cutoff = expiry_cutoff();
@@ -56,46 +130,31 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       const expiredTokens = await findExpiredTokens(cutoff);
       if (expiredTokens.length === 0) break;
 
-      let removed = 0;
+      const entityIds = [
+        ...new Set(
+          expiredTokens
+            .map((t) => t.entityId)
+            .filter((id): id is string => !!id),
+        ),
+      ];
+      const entitiesInUse = await findEntitiesInUse(entityIds, cutoff);
+
+      const entitiesRemoved = new Set<string>();
+      let handled = 0;
 
       for (const token of expiredTokens) {
-        const relationship = await prisma.relationship.findFirst({
-          where: {
-            entity_id: token.entityId,
-            product_id: token.productId,
-            status: "new",
-          },
-        });
+        // Deleting an entity takes its other tokens with it.
+        if (token.entityId && entitiesRemoved.has(token.entityId)) continue;
 
-        if (relationship) {
-          await prisma.$transaction([
-            // This entity's own unfinished relationships for this product.
-            prisma.relationship.deleteMany({
-              where: {
-                entity_id: token.entityId,
-                product_id: token.productId,
-                status: "new",
-              },
-            }),
-            // Delete the token
-            prisma.publicFormsTokens.delete({
-              where: { token: token.token },
-            }),
-            // Delete all corpus items associated with the entity
-            prisma.new_corpus.deleteMany({
-              where: { entity_id: token.entityId || "" },
-            }),
-            // Delete the entity (company)
-            prisma.entity.delete({
-              where: { id: token.entityId || "" },
-            }),
-          ]);
-          removed++;
+        const entityRemoved = await cleanUpToken(token, entitiesInUse, cutoff);
+        if (entityRemoved && token.entityId) {
+          entitiesRemoved.add(token.entityId);
         }
+        handled++;
       }
 
-      // A batch that removes nothing would be fetched again next time round.
-      if (removed === 0) {
+      // A batch that handles nothing would be fetched again next time round.
+      if (handled === 0) {
         console.warn("cleanup_unsubmitted_forms: no progress, stopping");
         break;
       }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -44,6 +44,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     for (const token of expiredTokens) {
       const relationship = await prisma.relationship.findFirst({
         where: {
+          entity_id: token.entityId,
           product_id: token.productId,
           status: "new",
         },
@@ -51,9 +52,13 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
 
       if (relationship) {
         await prisma.$transaction([
-          // Delete relationship
-          prisma.relationship.delete({
-            where: { id: relationship.id },
+          // This entity's own unfinished relationships for this product.
+          prisma.relationship.deleteMany({
+            where: {
+              entity_id: token.entityId,
+              product_id: token.productId,
+              status: "new",
+            },
           }),
           // // Delete the token
           prisma.publicFormsTokens.delete({

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -27,21 +27,18 @@ import type { JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
+const EXPIRY_DAYS = 7;
+
+export const expiry_cutoff = (now: Date = new Date()): Date =>
+  new Date(now.getTime() - EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
-    );
+    // No lower bound, so a missed run is picked up by the next one.
+    const cutoff = expiry_cutoff();
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
-      where: {
-        createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
-        },
-      },
+      where: { createdAt: { lt: cutoff } },
     });
 
     for (const token of expiredTokens) {

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -29,11 +29,19 @@ import { update_job_status } from "./generic_scheduler";
 
 const EXPIRY_DAYS = 7;
 const BATCH_SIZE = 500;
+const LOG_PREFIX = "cleanup_unsubmitted_forms";
 
 type ExpiredToken = {
   token: string;
   entityId: string | null;
   productId: string;
+};
+
+type BatchResult = {
+  entitiesDeleted: Set<string>;
+  entitiesKept: Set<string>;
+  handled: number;
+  failed: number;
 };
 
 export const expiry_cutoff = (now: Date = new Date()): Date =>
@@ -122,45 +130,87 @@ const cleanUpToken = async (
   return false;
 };
 
+const cleanUpBatch = async (
+  tokens: ExpiredToken[],
+  cutoff: Date,
+): Promise<BatchResult> => {
+  const entityIds = [
+    ...new Set(
+      tokens.map((t) => t.entityId).filter((id): id is string => !!id),
+    ),
+  ];
+  const entitiesInUse = await findEntitiesInUse(entityIds, cutoff);
+
+  const result: BatchResult = {
+    entitiesDeleted: new Set(),
+    entitiesKept: new Set(),
+    handled: 0,
+    failed: 0,
+  };
+
+  for (const token of tokens) {
+    // Deleting an entity takes its other tokens with it.
+    if (token.entityId && result.entitiesDeleted.has(token.entityId)) continue;
+
+    try {
+      const entityRemoved = await cleanUpToken(token, entitiesInUse, cutoff);
+
+      if (token.entityId) {
+        const bucket = entityRemoved
+          ? result.entitiesDeleted
+          : result.entitiesKept;
+        bucket.add(token.entityId);
+      }
+      result.handled++;
+    } catch (error) {
+      result.failed++;
+      console.error(`${LOG_PREFIX}: ${token.token} failed`, error);
+    }
+  }
+
+  return result;
+};
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     const cutoff = expiry_cutoff();
 
+    let scanned = 0;
+    let failed = 0;
+    // Sets, because one entity can own several tokens across several batches.
+    const deleted = new Set<string>();
+    const kept = new Set<string>();
+
     while (true) {
-      const expiredTokens = await findExpiredTokens(cutoff);
-      if (expiredTokens.length === 0) break;
+      const tokens = await findExpiredTokens(cutoff);
+      if (tokens.length === 0) break;
 
-      const entityIds = [
-        ...new Set(
-          expiredTokens
-            .map((t) => t.entityId)
-            .filter((id): id is string => !!id),
-        ),
-      ];
-      const entitiesInUse = await findEntitiesInUse(entityIds, cutoff);
+      scanned += tokens.length;
+      const batch = await cleanUpBatch(tokens, cutoff);
 
-      const entitiesRemoved = new Set<string>();
-      let handled = 0;
+      for (const id of batch.entitiesDeleted) deleted.add(id);
+      for (const id of batch.entitiesKept) kept.add(id);
+      failed += batch.failed;
 
-      for (const token of expiredTokens) {
-        // Deleting an entity takes its other tokens with it.
-        if (token.entityId && entitiesRemoved.has(token.entityId)) continue;
-
-        const entityRemoved = await cleanUpToken(token, entitiesInUse, cutoff);
-        if (entityRemoved && token.entityId) {
-          entitiesRemoved.add(token.entityId);
-        }
-        handled++;
-      }
-
-      // A batch that handles nothing would be fetched again next time round.
-      if (handled === 0) {
-        console.warn("cleanup_unsubmitted_forms: no progress, stopping");
+      // Every row in this batch failed, so the next pass would fetch the same
+      // ones again.
+      if (batch.handled === 0) {
+        console.warn(`${LOG_PREFIX}: no progress, stopping`);
         break;
       }
     }
 
-    await update_job_status(job.id, "completed");
+    console.log(
+      `${LOG_PREFIX}: ${scanned} tokens, ${deleted.size} entities deleted, ` +
+        `${kept.size} kept, ${failed} failed`,
+    );
+
+    // Only fail the run if nothing worked. One bad row shouldn't hide a run
+    // that did most of its job.
+    await update_job_status(
+      job.id,
+      deleted.size === 0 && failed > 0 ? "failed" : "completed",
+    );
   } catch (error) {
     console.error("Error cleaning up unsubmitted forms:", error);
     await update_job_status(job.id, "failed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -1,5 +1,5 @@
-/* Context: 
- This is a scheduled job that runs every day at midnight to clean up forms that users started filling in but didn't submit which are older than 7 days. 
+/* Context:
+ This is a scheduled job that runs every day at midnight to clean up forms that users started filling in but didn't submit which are older than 7 days.
  When a user visits a public form, a token is generated and stored in the database.
  This token is used to identify the user and link the answers to the entity.
  An entity is the owner of data in the database, separated as it could be a business or an individual but has been decoupled from a login/user.
@@ -28,53 +28,76 @@ import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
 const EXPIRY_DAYS = 7;
+const BATCH_SIZE = 500;
+
+type ExpiredToken = {
+  token: string;
+  entityId: string | null;
+  productId: string;
+};
 
 export const expiry_cutoff = (now: Date = new Date()): Date =>
   new Date(now.getTime() - EXPIRY_DAYS * 24 * 60 * 60 * 1000);
 
+// No lower bound, so a missed run is picked up by the next one. Deleted rows
+// stop matching, so taking the first N each time walks the whole set.
+const findExpiredTokens = (cutoff: Date): Promise<ExpiredToken[]> =>
+  prisma.publicFormsTokens.findMany({
+    where: { createdAt: { lt: cutoff } },
+    select: { token: true, entityId: true, productId: true },
+    take: BATCH_SIZE,
+  });
+
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    // No lower bound, so a missed run is picked up by the next one.
     const cutoff = expiry_cutoff();
 
-    const expiredTokens = await prisma.publicFormsTokens.findMany({
-      where: { createdAt: { lt: cutoff } },
-    });
+    while (true) {
+      const expiredTokens = await findExpiredTokens(cutoff);
+      if (expiredTokens.length === 0) break;
 
-    for (const token of expiredTokens) {
-      const relationship = await prisma.relationship.findFirst({
-        where: {
-          entity_id: token.entityId,
-          product_id: token.productId,
-          status: "new",
-        },
-      });
+      let removed = 0;
 
-      if (relationship) {
-        await prisma.$transaction([
-          // This entity's own unfinished relationships for this product.
-          prisma.relationship.deleteMany({
-            where: {
-              entity_id: token.entityId,
-              product_id: token.productId,
-              status: "new",
-            },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          }),
-          // Delete all corpus items associated with the entity
-          prisma.new_corpus.deleteMany({
-            where: {
-              entity_id: token.entityId || "",
-            },
-          }),
-          // Delete the entity (company)
-          prisma.entity.delete({
-            where: { id: token.entityId || "" },
-          }),
-        ]);
+      for (const token of expiredTokens) {
+        const relationship = await prisma.relationship.findFirst({
+          where: {
+            entity_id: token.entityId,
+            product_id: token.productId,
+            status: "new",
+          },
+        });
+
+        if (relationship) {
+          await prisma.$transaction([
+            // This entity's own unfinished relationships for this product.
+            prisma.relationship.deleteMany({
+              where: {
+                entity_id: token.entityId,
+                product_id: token.productId,
+                status: "new",
+              },
+            }),
+            // Delete the token
+            prisma.publicFormsTokens.delete({
+              where: { token: token.token },
+            }),
+            // Delete all corpus items associated with the entity
+            prisma.new_corpus.deleteMany({
+              where: { entity_id: token.entityId || "" },
+            }),
+            // Delete the entity (company)
+            prisma.entity.delete({
+              where: { id: token.entityId || "" },
+            }),
+          ]);
+          removed++;
+        }
+      }
+
+      // A batch that removes nothing would be fetched again next time round.
+      if (removed === 0) {
+        console.warn("cleanup_unsubmitted_forms: no progress, stopping");
+        break;
       }
     }
 


### PR DESCRIPTION
## What was wrong

The cleanup job was using the wrong cutoff and could delete the wrong entity.

It was checking for a `new` relationship to decide whether to delete both the token and the entity. That meant expired tokens could stay forever, while an entity could be deleted even though it belonged to a completed application. The relationship query was also not scoped to the entity, so it could match another business.

## The main change

The token and entity are now handled separately:

- Expired tokens are deleted on their own.
- An entity is deleted only when no unexpired token or relationship beyond `new` still points to it.
- We check again inside the transaction, since the first check is seconds old by then and someone could have finished their form in the meantime.

When the data is unclear, we keep the entity. Leaving a row to clean up later is safer than deleting someone's application by mistake. This also protects businesses that have more than one token across different products.

## Other fixes

- Fixed the cutoff. `7 * 24 * 60 * 60` is seconds and `Date.now()` is milliseconds, so it came out as 10 minutes instead of 7 days.
- Removed the one-day query limit, so missed runs can catch up.
- Scoped relationship checks to both `product_id` and `entity_id`.
- A missing entity no longer crashes the job.
- One failed row no longer stops the whole run. It only reports failed if nothing worked at all, and the counts are in the log.
- The scan now processes 500 tokens at a time instead of running one query per token.

I left the delete order alone. Children before parent was already right, and I would rather check the schema than start moving statements around in something that deletes data.

## When this first runs

Because of the cutoff bug, the first run will work through the whole backlog that has built up since launch. Worth counting the rows older than seven days first and having a look at the number, since none of this can be undone.

Which could be an argument for soft delete. Mark the entity, remove it properly a month later, and a mistake won't be permanent. That is not in here because adding a `deleted_at` means every query that touches entity has to start ignoring the deleted ones, and that reaches well beyond this file.

## Product Question?

Should we notify people before deleting an incomplete funding application?

These entities are businesses that started an application but did not finish it. They may be useful leads, and right now we delete them silently on day seven.

The context at the top of this file says these entities get alerts about their profile. If that is already live, a reminder is one more message on that path. Some people would go back and finish, and for the rest the deletion won't be a surprise.