### PR TITLE
`fix`: cleanup of unsubmitted public forms older than 7 days

### DIFF
--- a/tests/unsubmitted_forms/README.md
+++ b/tests/unsubmitted_forms/README.md
@@ -1,0 +1,45 @@
+---
+title: Cleanup Unsubmitted forms
+description: Daily job that deletes public-form tokens older than 7 days, plus linked unsubmitted entity data.
+---
+
+# Cleanup unsubmitted forms
+
+Scheduled job: `cleanup_unsubmitted_forms`.
+
+Runs every day at midnight. Deletes public-form sessions that were started but never submitted and are older than 7 days, along with the unused entity data they created.
+
+## Why it exists
+
+When a user opens a public form, the system stores a **token**. That token identifies the session and links answers to an **entity** — a Vula profile for a business or individual, separate from a login.
+
+If the user never submits, those rows are unused. This job removes them so tokens and entities do not accumulate.
+
+## What it deletes
+
+For each token with `createdAt` **older than 7 days**:
+
+| Token state | Deleted |
+| --- | --- |
+| No `entityId` | Token only |
+| `entityId` set, matching `new` relationship | Relationship, token, corpus rows, entity |
+| `entityId` set, no matching `new` relationship | Token, corpus rows, entity |
+
+The relationship match is `product_id` + `entity_id` + `status: "new"`, so another entity on the same product is not removed.
+
+Deletes for a single token run in one Prisma transaction.
+
+## Job status
+
+| Outcome | Status |
+| --- | --- |
+| Every token cleaned successfully | `completed` |
+| One or more tokens failed (logged; others continue) | `failed` |
+| Unexpected error (for example the initial query) | `failed`, error rethrown |
+
+## Performance
+
+- Cutoff is `Date.now() - 7 * 24 * 60 * 60 * 1000` (milliseconds).
+- Filter is `createdAt < cutoff`, so a missed run still picks up older tokens.
+- Tokens are processed in batches of 100.
+- Relationships for each batch are loaded with one `findMany`, then looked up in a `Map`.

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -77,6 +77,22 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
             where: { id: token.entityId },
           }),
         ]);
+      } else {
+        // No matching unsubmitted relationship — still remove the expired token
+        // and any entity/corpus left behind from an abandoned form
+        await prisma.$transaction([
+          prisma.publicFormsTokens.delete({
+            where: { token: token.token },
+          }),
+          prisma.new_corpus.deleteMany({
+            where: {
+              entity_id: token.entityId,
+            },
+          }),
+          prisma.entity.delete({
+            where: { id: token.entityId },
+          }),
+        ]);
       }
     }
 

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -23,10 +23,44 @@
  */
 
 // For the purpose of this test you can ignore that the imports are not working.
+/**
+ * @module unsubmitted_forms
+ * @packageDocumentation
+ * Daily job that removes unsubmitted public-form tokens older than 7 days
+ * and any leftover entity, corpus, and `new` relationship rows they created.
+ */
 import type { JobScheduleQueue } from "@prisma/client";
 import { prisma } from "../endpoints/middleware/prisma";
 import { update_job_status } from "./generic_scheduler";
 
+/**
+ * Daily midnight job that deletes unsubmitted public-form data older than 7 days.
+ *
+ * A public-form visit creates a token that links answers to an **entity** (a Vula
+ * profile for a business or individual, not a login). If the form is never
+ * submitted, this job removes the expired token and any leftover unsubmitted
+ * records so they do not clutter the database.
+ *
+ * For each expired token the job:
+ * 1. Deletes only the token when `entityId` is missing.
+ * 2. Loads the matching `new` relationship by `product_id` + `entity_id`.
+ * 3. In a transaction, deletes the relationship (if any), token, corpus rows, and entity.
+ *
+ * Tokens are processed in batches of 100. Relationships for each batch are
+ * loaded with a single `findMany` and indexed by `product_id:entity_id`.
+ * Per-token failures are logged and skipped; remaining tokens still run.
+ *
+ * Job status is `completed` when every token succeeds, or `failed` if any
+ * token fails. Unexpected errors (for example the initial query) also mark
+ * the job `failed` and are rethrown.
+ *
+ * @param job - Scheduler queue record for this run. `job.id` is used to update status.
+ * @returns Resolves after job status has been written.
+ * @throws Rethrows unexpected errors after marking the job `failed`.
+ *
+ * @example
+ * await cleanup_unsubmitted_forms(job);
+ */
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     // Find forms older than 7 days that have not been submitted

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -29,17 +29,13 @@ import { update_job_status } from "./generic_scheduler";
 
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
-    //Find forms that were created 7 days ago and have not been submitted
+    // Find forms older than 7 days that have not been submitted
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const sevenDaysAgoPlusOneDay = new Date(
-      sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
-    );
 
     const expiredTokens = await prisma.publicFormsTokens.findMany({
       where: {
         createdAt: {
-          gte: sevenDaysAgo, // greater than or equal to 7 days ago
-          lt: sevenDaysAgoPlusOneDay, // but less than 7 days ago + 1 day
+          lt: sevenDaysAgo,
         },
       },
     });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,6 +41,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     });
 
     const BATCH_SIZE = 100;
+    let failureCount = 0;
 
     for (let i = 0; i < expiredTokens.length; i += BATCH_SIZE) {
       const batch = expiredTokens.slice(i, i + BATCH_SIZE);
@@ -69,59 +70,70 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       );
 
       for (const token of batch) {
-        if (!token.entityId) {
-          await prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          });
-          continue;
-        }
-
-        const relationship = relationshipByKey.get(
-          `${token.productId}:${token.entityId}`,
-        );
-
-        if (relationship) {
-          await prisma.$transaction([
-            // Delete relationship
-            prisma.relationship.delete({
-              where: { id: relationship.id },
-            }),
-            // // Delete the token
-            prisma.publicFormsTokens.delete({
+        try {
+          if (!token.entityId) {
+            await prisma.publicFormsTokens.delete({
               where: { token: token.token },
-            }),
-            // Delete all corpus items associated with the entity
-            prisma.new_corpus.deleteMany({
-              where: {
-                entity_id: token.entityId,
-              },
-            }),
-            // Delete the entity (company)
-            prisma.entity.delete({
-              where: { id: token.entityId },
-            }),
-          ]);
-        } else {
-          // No matching unsubmitted relationship — still remove the expired token
-          // and any entity/corpus left behind from an abandoned form
-          await prisma.$transaction([
-            prisma.publicFormsTokens.delete({
-              where: { token: token.token },
-            }),
-            prisma.new_corpus.deleteMany({
-              where: {
-                entity_id: token.entityId,
-              },
-            }),
-            prisma.entity.delete({
-              where: { id: token.entityId },
-            }),
-          ]);
+            });
+            continue;
+          }
+
+          const relationship = relationshipByKey.get(
+            `${token.productId}:${token.entityId}`,
+          );
+
+          if (relationship) {
+            await prisma.$transaction([
+              // Delete relationship
+              prisma.relationship.delete({
+                where: { id: relationship.id },
+              }),
+              // // Delete the token
+              prisma.publicFormsTokens.delete({
+                where: { token: token.token },
+              }),
+              // Delete all corpus items associated with the entity
+              prisma.new_corpus.deleteMany({
+                where: {
+                  entity_id: token.entityId,
+                },
+              }),
+              // Delete the entity (company)
+              prisma.entity.delete({
+                where: { id: token.entityId },
+              }),
+            ]);
+          } else {
+            // No matching unsubmitted relationship — still remove the expired token
+            // and any entity/corpus left behind from an abandoned form
+            await prisma.$transaction([
+              prisma.publicFormsTokens.delete({
+                where: { token: token.token },
+              }),
+              prisma.new_corpus.deleteMany({
+                where: {
+                  entity_id: token.entityId,
+                },
+              }),
+              prisma.entity.delete({
+                where: { id: token.entityId },
+              }),
+            ]);
+          }
+        } catch (tokenError) {
+          failureCount += 1;
+          console.error(
+            `Error cleaning up unsubmitted form token ${token.token}:`,
+            tokenError,
+          );
         }
       }
     }
 
-    await update_job_status(job.id, "completed");
+    await update_job_status(
+      job.id,
+      failureCount > 0 ? "failed" : "completed",
+    );
   } catch (error) {
     console.error("Error cleaning up unsubmitted forms:", error);
     await update_job_status(job.id, "failed");

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -44,6 +44,7 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       const relationship = await prisma.relationship.findFirst({
         where: {
           product_id: token.productId,
+          entity_id: token.entityId,
           status: "new",
         },
       });

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -41,6 +41,13 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
     });
 
     for (const token of expiredTokens) {
+      if (!token.entityId) {
+        await prisma.publicFormsTokens.delete({
+          where: { token: token.token },
+        });
+        continue;
+      }
+
       const relationship = await prisma.relationship.findFirst({
         where: {
           product_id: token.productId,
@@ -62,12 +69,12 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
           // Delete all corpus items associated with the entity
           prisma.new_corpus.deleteMany({
             where: {
-              entity_id: token.entityId || "",
+              entity_id: token.entityId,
             },
           }),
           // Delete the entity (company)
           prisma.entity.delete({
-            where: { id: token.entityId || "" },
+            where: { id: token.entityId },
           }),
         ]);
       }

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -30,7 +30,7 @@ import { update_job_status } from "./generic_scheduler";
 export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
   try {
     //Find forms that were created 7 days ago and have not been submitted
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60);
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const sevenDaysAgoPlusOneDay = new Date(
       sevenDaysAgo.getTime() + 24 * 60 * 60 * 1000,
     );

--- a/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
+++ b/tests/unsubmitted_forms/cleanup_unsubmitted_forms.ts
@@ -40,59 +40,84 @@ export const cleanup_unsubmitted_forms = async (job: JobScheduleQueue) => {
       },
     });
 
-    for (const token of expiredTokens) {
-      if (!token.entityId) {
-        await prisma.publicFormsTokens.delete({
-          where: { token: token.token },
-        });
-        continue;
-      }
+    const BATCH_SIZE = 100;
 
-      const relationship = await prisma.relationship.findFirst({
-        where: {
-          product_id: token.productId,
-          entity_id: token.entityId,
-          status: "new",
-        },
-      });
+    for (let i = 0; i < expiredTokens.length; i += BATCH_SIZE) {
+      const batch = expiredTokens.slice(i, i + BATCH_SIZE);
+      const tokensWithEntity = batch.filter((token) => token.entityId);
 
-      if (relationship) {
-        await prisma.$transaction([
-          // Delete relationship
-          prisma.relationship.delete({
-            where: { id: relationship.id },
-          }),
-          // // Delete the token
-          prisma.publicFormsTokens.delete({
+      const relationships =
+        tokensWithEntity.length > 0
+          ? await prisma.relationship.findMany({
+              where: {
+                status: "new",
+                product_id: {
+                  in: tokensWithEntity.map((token) => token.productId),
+                },
+                entity_id: {
+                  in: tokensWithEntity.map((token) => token.entityId as string),
+                },
+              },
+            })
+          : [];
+
+      const relationshipByKey = new Map(
+        relationships.map((relationship) => [
+          `${relationship.product_id}:${relationship.entity_id}`,
+          relationship,
+        ]),
+      );
+
+      for (const token of batch) {
+        if (!token.entityId) {
+          await prisma.publicFormsTokens.delete({
             where: { token: token.token },
-          }),
-          // Delete all corpus items associated with the entity
-          prisma.new_corpus.deleteMany({
-            where: {
-              entity_id: token.entityId,
-            },
-          }),
-          // Delete the entity (company)
-          prisma.entity.delete({
-            where: { id: token.entityId },
-          }),
-        ]);
-      } else {
-        // No matching unsubmitted relationship — still remove the expired token
-        // and any entity/corpus left behind from an abandoned form
-        await prisma.$transaction([
-          prisma.publicFormsTokens.delete({
-            where: { token: token.token },
-          }),
-          prisma.new_corpus.deleteMany({
-            where: {
-              entity_id: token.entityId,
-            },
-          }),
-          prisma.entity.delete({
-            where: { id: token.entityId },
-          }),
-        ]);
+          });
+          continue;
+        }
+
+        const relationship = relationshipByKey.get(
+          `${token.productId}:${token.entityId}`,
+        );
+
+        if (relationship) {
+          await prisma.$transaction([
+            // Delete relationship
+            prisma.relationship.delete({
+              where: { id: relationship.id },
+            }),
+            // // Delete the token
+            prisma.publicFormsTokens.delete({
+              where: { token: token.token },
+            }),
+            // Delete all corpus items associated with the entity
+            prisma.new_corpus.deleteMany({
+              where: {
+                entity_id: token.entityId,
+              },
+            }),
+            // Delete the entity (company)
+            prisma.entity.delete({
+              where: { id: token.entityId },
+            }),
+          ]);
+        } else {
+          // No matching unsubmitted relationship — still remove the expired token
+          // and any entity/corpus left behind from an abandoned form
+          await prisma.$transaction([
+            prisma.publicFormsTokens.delete({
+              where: { token: token.token },
+            }),
+            prisma.new_corpus.deleteMany({
+              where: {
+                entity_id: token.entityId,
+              },
+            }),
+            prisma.entity.delete({
+              where: { id: token.entityId },
+            }),
+          ]);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes the daily `cleanup_unsubmitted_forms` job so it actually deletes unsubmitted public-form tokens older than 7 days, plus leftover relationship, corpus, and entity rows.
- Corrects date math, age filtering, relationship scoping, null `entityId` handling, and orphan tokens that were previously skipped.
- Batches relationship lookups and isolates per-token failures so one bad row does not stop the run.

## What changed
1. Cutoff uses milliseconds (`* 1000`) so the window is 7 days, not ~7 minutes.
2. Filter is `createdAt < sevenDaysAgo` so a missed run still catches older tokens.
3. Relationship match includes `entity_id` as well as `product_id` and `status: "new"`.
4. Tokens with no `entityId` only delete the token (never `""`).
5. Expired tokens with no matching `new` relationship still get cleaned up.
6. Relationships are batch-loaded (`findMany` + `Map`) in chunks of 100 instead of one `findFirst` per token.
7. Per-token try/catch; job status is `failed` if any item failed, else `completed`.
8. Added TSDoc and a short README for the job.

## Test plan
- [ ] Reason about date math: `Date.now() - 7 * 24 * 60 * 60 * 1000` is 7 days in ms
- [ ] Missed-run catch-up: a token 10 days old is still selected (`lt`, not a 1-day window)
- [ ] Wrong-entity risk: two entities on the same product cannot share a `new` relationship delete
- [ ] Null `entityId`: token is deleted; entity/corpus deletes are skipped
- [ ] Orphans: no `new` relationship still deletes token + corpus + entity
- [ ] One failing token is logged and the rest of the batch continues
- [ ] Job status is `completed` only when every token succeeds